### PR TITLE
Update Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/callumacrae/find-node-modules",
   "dependencies": {
-    "findup-sync": "^0.2.1",
+    "findup-sync": "^0.4.1",
     "merge": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- update `findup-sync` dependency to `^v0.4.1`

Tests appear to hang, locally.  Hopefully this is just a local issue...?

Fixes #4
