### PR TITLE
update dependencies and escape from loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,14 +26,20 @@ module.exports = function findNodeModules(options) {
 	var modulesArray = [];
 	var searchDir = options.cwd;
 	var modulesDir;
+	var duplicateFound = false;
 
 	do {
 		modulesDir = findup(options.searchFor, { cwd: searchDir });
 
 		if (modulesDir !== null) {
-			modulesArray.push(formatPath(modulesDir, options));
+			var foundModulesDir = formatPath(modulesDir, options);
+			duplicateFound = (modulesArray.indexOf(foundModulesDir) > -1);
+			if (!duplicateFound) {
+				modulesArray.push(foundModulesDir);
+				searchDir = path.join(modulesDir, '../../');
+			}
 		}
-	} while (modulesDir && (searchDir = path.join(modulesDir, '../../')));
+	} while (modulesDir && !duplicateFound);
 
 	return modulesArray;
 };

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   },
   "homepage": "https://github.com/callumacrae/find-node-modules",
   "dependencies": {
-    "findup-sync": "^0.2.1",
+    "findup-sync": "0.4.2",
     "merge": "^1.2.0"
   },
   "devDependencies": {
     "faucet": "0.0.1",
-    "tape": "^3.5.0"
+    "tape": "4.6.0"
   }
 }


### PR DESCRIPTION
Fix for issue #4 including upgrading findup-sync;  detect when a duplicate directory has been found to determine when to exit the while loop. findup() was returning the same directory once it got to the top of the search.  
