### PR TITLE
chore(deps): update findup-sync from 0.4.2 to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/callumacrae/find-node-modules",
   "dependencies": {
-    "findup-sync": "0.4.2",
+    "findup-sync": "^3.0.0",
     "merge": "^1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolves vulnerability in `braces` <=2.3.0
More info: https://nodesecurity.io/advisories/786

I ran tests on `findup-sync` v1, 2 and 3 with success. `findup-sync` v2 and v3 were released on the same day (https://github.com/gulpjs/findup-sync/releases). `npm audit` is recommending v3+, so I chose to use `^3.0.0`. I did not commit `package-lock.json` file as it did not already exist in the repo.

This issue, triggering an npm audit warning, was being experienced upstream in commitzen. After this fix is released, the following issue can be resolved easily:
https://github.com/commitizen/cz-cli/issues/609
