### PR TITLE
chore(deps): update findup-sync from 3.0.0 to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/callumacrae/find-node-modules",
   "dependencies": {
-    "findup-sync": "^3.0.0",
+    "findup-sync": "^4.0.0",
     "merge": "^1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates `findup-sync` to the latest `4.0.0`.

I received a security warning about the `set-value` package that needs to be upgraded and following the trace where it originated it is your package 😊 

```
set-value > union-value > cache-base > base > snapdragon > expand-brackets > extglob > micromatch > findup-sync > find-node-modules
```