### PR TITLE
Upgrade lib merge 1.2.1=>2.1.0 and bump package version to 2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -339,9 +339,9 @@
       "dev": true
     },
     "merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.0.tgz",
+      "integrity": "sha512-TcuhVDV+e6X457MQAm7xIb19rWhZuEDEho7RrwxMpQ/3GhD5sDlnP188gjQQuweXHy9igdke5oUtVOXX1X8Sxg=="
     },
     "micromatch": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "find-node-modules",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Return an array of all parent node_modules directories",
   "main": "index.js",
   "scripts": {
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/callumacrae/find-node-modules",
   "dependencies": {
     "findup-sync": "^4.0.0",
-    "merge": "^1.2.1"
+    "merge": "^2.1.0"
   },
   "devDependencies": {
     "faucet": "0.0.1",


### PR DESCRIPTION
There is a security vulnerability found in the lib merge 1.2.1. See https://github.com/yeikos/js.merge/pull/38. So upgrade to 2.1.0+ to fix it.